### PR TITLE
Remove old etc attribution info

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,3 @@ Ethereum clients as swappable modules.
 ## Contributing
 
 The specification is written in [OpenRPC](https://open-rpc.org/).
-
-## Attribution
-
-This specification was originally developed by [ETC
-Core](https://github.com/etclabscore/ethereum-json-rpc-specification) and is
-licensed under the Apache 2.0 license.


### PR DESCRIPTION
Forgot to remove this after rewriting from scratch under CC0.