### PR TITLE
Allow gasPrice to co-exist with 1559 tx props

### DIFF
--- a/openrpc.json
+++ b/openrpc.json
@@ -1088,7 +1088,7 @@
 						}
 					},
 					{
-						"oneOf": [
+						"anyOf": [
 							{
 								"title": "EIP-1559 fee market parameters",
 								"type": "object",


### PR DESCRIPTION
EIP 1559 currently introduces a breaking change that will impact an unknown number of web3 sites in production. At the very least, we have become aware that some versions of ethers.js will crash on receiving a transaction object that was signed using 1559.

This is because some code blindly expects a `gasPrice` parameter on a returned transaction object, and the current specification excludes this property when the `maxFeePerGas` and `maxPriorityFeePerGas` are present.

This spec change allows these properties to co-exist, but *this PR represents a recommendation to all client and wallet developers**: To avoid breaking live dapps in production, you should polyfill a `gasPrice` value on any methods that return a `Transaction` object.

Current methods affected by this issue are at least:
- `eth_getTransactionByHash`
- `eth_getTransactionByBlockHashAndIndex`

I know, this is a little weird, since it would mean these methods return a property that was not part of the signed payload, and that will probably cause some pushback, but I think that kind of idealism needs to be balanced with the pragmatism of [not breaking user space](https://lkml.org/lkml/2012/12/23/75).